### PR TITLE
Fix StringBuffer resizing

### DIFF
--- a/StringFormatter/StringBuffer.cs
+++ b/StringFormatter/StringBuffer.cs
@@ -418,8 +418,7 @@ namespace System.Text.Formatting {
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        void CheckCapacity (int count)
-        {
+        void CheckCapacity (int count) {
             var desiredCapacity = currentCount + count;
             if (desiredCapacity > buffer.Length)
                 Array.Resize(ref buffer, desiredCapacity * 2);

--- a/StringFormatter/StringBuffer.cs
+++ b/StringFormatter/StringBuffer.cs
@@ -418,9 +418,11 @@ namespace System.Text.Formatting {
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        void CheckCapacity (int count) {
-            if (currentCount + count > buffer.Length)
-                Array.Resize(ref buffer, buffer.Length * 2);
+        void CheckCapacity (int count)
+        {
+            var desiredCapacity = currentCount + count;
+            if (desiredCapacity > buffer.Length)
+                Array.Resize(ref buffer, desiredCapacity * 2);
         }
 
         bool AppendSegment<T>(ref char* currRef, char* end, char* dest, ref int prevArgIndex, ref T args) where T : IArgSet {


### PR DESCRIPTION
On second thought, I chose to resize to twice the required size. It's how it's done in `List<T>`.