### PR TITLE
Support truncating the string through setting the Count property

### DIFF
--- a/StringFormatter/StringBuffer.cs
+++ b/StringFormatter/StringBuffer.cs
@@ -45,7 +45,14 @@ namespace System.Text.Formatting {
         /// The number of characters in the buffer.
         /// </summary>
         public int Count {
-            get { return currentCount; }
+            get => currentCount;
+            set
+            {
+                if (value < currentCount)
+                    currentCount = value;
+                else if (value > currentCount)
+                    Append('\0', value - currentCount);
+            }
         }
 
         /// <summary>
@@ -439,7 +446,7 @@ namespace System.Text.Formatting {
         {
             GuidFormatting.Format(this, value, format);
         }
-        
+
         /// <summary>
         /// Appends the string returned by processing a composite format string, which contains zero or more format items, to this instance.
         /// Each format item is replaced by the string representation of a single argument.

--- a/Test/StringBufferTests.cs
+++ b/Test/StringBufferTests.cs
@@ -1,0 +1,55 @@
+﻿using System;
+using System.Text.Formatting;
+using NFluent;
+using NUnit.Framework;
+
+namespace Test
+{
+    [TestFixture]
+    public class StringBufferTests
+    {
+        [Test]
+        public void lowering_count_shortens_string()
+        {
+            var buffer = new StringBuffer(128);
+
+            buffer.Append("XXXXXXXXXzzzzzzzzz");
+
+            Check.That(buffer.ToString()).IsEqualTo("XXXXXXXXXzzzzzzzzz");
+
+            buffer.Count = 9;
+
+            Check.That(buffer.ToString()).IsEqualTo("XXXXXXXXX");
+
+            buffer.Append('w', 9);
+
+            Check.That(buffer.ToString()).IsEqualTo("XXXXXXXXXwwwwwwwww");
+        }
+
+        [Test]
+        public void increasing_count_pads_with_nulls_and_increases_capacity()
+        {
+            var buffer = new StringBuffer(9);
+
+            buffer.Append("XXXXXXXXX");
+
+            Check.That(buffer.ToString()).IsEqualTo("XXXXXXXXX");
+
+            buffer.Count = buffer.Count * 2;
+
+            Check.That(buffer.Count).IsEqualTo(18);
+
+            char[] dest = new char[18];
+
+            buffer.CopyTo(0, dest, 0, 18);
+
+            for (var i = 0; i < 9; i++)
+                Check.That((int) dest[i]).IsEqualTo('X');
+
+            for (var i = 9; i < 18; i++)
+                Check.That((int) dest[i]).IsEqualTo(0);
+        }
+
+    }
+
+}

--- a/Test/Test.csproj
+++ b/Test/Test.csproj
@@ -58,6 +58,7 @@
     <Compile Include="NumericTests.cs" />
     <Compile Include="Program.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="StringBufferTests.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\StringFormatter\StringFormatter.csproj">


### PR DESCRIPTION
This PR adds the ability to rewind/reset the `StringBuffer`'s current position by setting the `Count` property to the new length.

Added a test to verify the correctness.

Would greatly appreciate incorporating this ASAP (assuming the changes are acceptable technically) and releasing a 1.0.6 release from this so I can use it :)