### PR TITLE
Default TimeSpan formatting

### DIFF
--- a/StringFormatter/Date.cs
+++ b/StringFormatter/Date.cs
@@ -11,7 +11,7 @@ namespace System.Text.Formatting
 
             if (IsStandardShortFormat(format))
             {
-                var(year, month, day) = dateTime;
+                var (year, month, day) = dateTime;
                 AppendNumber(formatter, year, 4, tempChars, tempCharsLength);
                 formatter.Append('-');
                 AppendNumber(formatter, month, 2, tempChars, tempCharsLength);
@@ -56,16 +56,22 @@ namespace System.Text.Formatting
 
         public static unsafe void Format(StringBuffer formatter, TimeSpan timeSpan, StringView format)
         {
-            var tempCharsLength = 3;
+            var tempCharsLength = 7;
             char* tempChars = stackalloc char[tempCharsLength];
 
-            AppendNumber(formatter, timeSpan.Hours, 2, tempChars, tempCharsLength);
+            var (days, hours, minutes, seconds, ticks) = timeSpan;
+
+            if (days > 0) {
+                formatter.Append(days, format);
+                formatter.Append('.');
+            }
+            AppendNumber(formatter, hours, 2, tempChars, tempCharsLength);
             formatter.Append(':');
-            AppendNumber(formatter, timeSpan.Minutes, 2, tempChars, tempCharsLength);
+            AppendNumber(formatter, minutes, 2, tempChars, tempCharsLength);
             formatter.Append(':');
-            AppendNumber(formatter, timeSpan.Seconds, 2, tempChars, tempCharsLength);
+            AppendNumber(formatter, seconds, 2, tempChars, tempCharsLength);
             formatter.Append('.');
-            AppendNumber(formatter, timeSpan.Milliseconds, 3, tempChars, tempCharsLength);
+            AppendNumber(formatter, ticks, 7, tempChars, tempCharsLength);
         }
 
         private static unsafe void AppendNumber(StringBuffer formatter, int value, int maxLength, char* tempChars, int tempCharsLength)

--- a/StringFormatter/DeconstructionExtensions.cs
+++ b/StringFormatter/DeconstructionExtensions.cs
@@ -4,8 +4,9 @@ namespace System.Text.Formatting
 {
     public static class DeconstructionExtensions
     {
-        private const long TicksPerMillisecond = 10000;
-        private const long TicksPerSecond = TicksPerMillisecond * 1000;
+        private const long TicksPerMicroSeconds = 10;
+        private const long TicksPerMillisecond = 10_000;
+        private const long TicksPerSecond = TicksPerMillisecond * 1_000;
         private const long TicksPerMinute = TicksPerSecond * 60;
         private const long TicksPerHour = TicksPerMinute * 60;
         private const long TicksPerDay = TicksPerHour * 24;
@@ -16,18 +17,25 @@ namespace System.Text.Formatting
         private static readonly int[] DaysToMonth365 = {0, 31, 59, 90, 120, 151, 181, 212, 243, 273, 304, 334, 365};
         private static readonly int[] DaysToMonth366 = {0, 31, 60, 91, 121, 152, 182, 213, 244, 274, 305, 335, 366};
 
+        public static void Deconstruct(this TimeSpan timeSpan, out int days, out int hours, out int minutes, out int seconds, out int ticks)
+        {
+            var t = timeSpan.Ticks;
+            days         = (int)(t / (TicksPerHour * 24));
+            hours        = (int)((t / TicksPerHour) % 24);
+            minutes      = (int)((t / TicksPerMinute) % 60);
+            seconds      = (int)((t / TicksPerSecond) % 60);
+            ticks = (int)(t % 10_000_000);
+        }
+
         public static void Deconstruct(this DateTime date, out int year, out int month, out int day, out int hour, out int minute, out int second, out int millisecond)
         {
-            var (y, m, d) = date;
-            year = y;
-            month = m;
-            day = d;
+            (year, month, day) = date;
 
             var ticks = date.Ticks;
             hour = (int)((ticks / TicksPerHour) % 24);
             minute = (int)((ticks / TicksPerMinute) % 60);
             second = (int)((ticks / TicksPerSecond) % 60);
-            millisecond = (int)((ticks / TicksPerMillisecond) % 1000);
+            millisecond = (int)((ticks / TicksPerMillisecond) % 1_000);
         }
 
         public static void Deconstruct(this DateTime date, out int year, out int month, out int day)

--- a/Test/DateFormatTests.cs
+++ b/Test/DateFormatTests.cs
@@ -21,7 +21,7 @@ namespace Test
         {
             var buffer = new StringBuffer();
             buffer.AppendFormat("Date {0}", new DateTime(2017, 01, 15, 11, 01, 55, 843));
-            
+
             Check.That(buffer.ToString()).IsEqualTo("Date 2017-01-15 11:01:55.843");
         }
 
@@ -52,20 +52,30 @@ namespace Test
         {
             var buffer = new StringBuffer();
             buffer.AppendFormat("Timespan {0}", new TimeSpan(11, 01, 55));
-            
-            Check.That(buffer.ToString()).IsEqualTo("Timespan 11:01:55.000");
+
+            Check.That(buffer.ToString()).IsEqualTo("Timespan 11:01:55.0000000");
         }
+
+        [Test]
+        public void should_format_with_standard_timespan_format_when_more_than_one_day()
+        {
+            var buffer = new StringBuffer();
+            buffer.AppendFormat("Timespan {0}", new TimeSpan(666, 11, 01, 55, 333));
+
+            Check.That(buffer.ToString()).IsEqualTo("Timespan 666.11:01:55.3330000");
+        }
+
 
         [Test]
         [Repeat(50)]
         public void should_format_many_with_standard_timespan_format()
         {
             var buffer = new StringBuffer();
-            
+
             var timeSpan = TimeSpan.FromSeconds(_fixture.Create<int>());
             buffer.AppendFormat("Timespan {0}", timeSpan);
 
-            Check.That(buffer.ToString()).IsEqualTo($"Timespan {timeSpan.ToString(@"hh\:mm\:ss\.fff")}");
+            Check.That(buffer.ToString()).IsEqualTo($"Timespan {timeSpan.ToString(@"hh\:mm\:ss\.fffffff")}");
         }
     }
 }


### PR DESCRIPTION
Make default TimeSpan formatting slightly more efficient, and fully compatible with the way TimeSpan.ToString() does it...

In "standard" .NET, when a TimeSpan value is printed/converted to string by default we get the full 100ns value as fraction of seconds, and when the TimeSpan spans over a single day, the # of days will also be printed as can be seen for the very simple interactive session below:

```c#
$ csharp    
Mono C# Shell, type "help;" for help

Enter statements below.
csharp> using System.Text;
csharp> var sb = new StringBuilder();
csharp> sb.Append(DateTime.Now.TimeOfDay) 
14:05:39.1231810
csharp> var sb = new StringBuilder();
csharp> sb.Append(DateTime.Now.Subtract(new DateTime(2018,1,1)))
135.14:01:13.5298470
```

This PR makes the StringFormatter behave in the same way .NET `StringBuilder` class behaves...

This will change the default way that StringFormatter outputs TimeSpan values, but I think this makes some sense for the sake of consistency with regular .NET / new user expectations...