### PR TITLE
Add basic Span<T> support for CopyTo/Append

### DIFF
--- a/StringFormatter/StringFormatter.csproj
+++ b/StringFormatter/StringFormatter.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <OutputType>Library</OutputType>
     <VersionPrefix>1.0.0.7</VersionPrefix>
-    <TargetFrameworks>net461;netstandard1.5</TargetFrameworks>
+    <TargetFrameworks>net461;netstandard2.0;netcoreapp2.1</TargetFrameworks>
     <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <Description>Zero-allocation string formatting for .NET (a fork of https://github.com/MikePopoloski/StringFormatter)</Description>
@@ -18,9 +18,10 @@
     <PackageLicenseUrl>https://github.com/MendelMonteiro/StringFormatter/blob/master/LICENSE</PackageLicenseUrl>
   </PropertyGroup>
   <ItemGroup>
+    <PackageReference Include="System.Memory" Version="4.5.1" />
     <PackageReference Include="System.Reflection" Version="4.3.0" />
-    <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="4.4.0" />
-    <PackageReference Include="System.ValueTuple" Version="4.4.0" />
+    <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="4.5.2" />
+    <PackageReference Include="System.ValueTuple" Version="4.5.0" />
   </ItemGroup>
   <ItemGroup>
     <Reference Include="netstandard" />

--- a/StringFormatterBench/app.config
+++ b/StringFormatterBench/app.config
@@ -1,6 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<configuration>
-  <startup>
-    <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.6.1"/>
-  </startup>
-</configuration>

--- a/Test/Test.csproj
+++ b/Test/Test.csproj
@@ -3,8 +3,10 @@
   <PropertyGroup>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <TargetFrameworks>net461;netcoreapp2.1</TargetFrameworks>
+    <LangVersion>latest</LangVersion>
   </PropertyGroup>
   <ItemGroup>
+    <PackageReference Include="System.Memory" Version="4.5.1" />
     <PackageReference Include="AutoFixture" Version="3.50.5" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
     <PackageReference Include="NFluent" Version="1.3.1" />


### PR DESCRIPTION
- Per the suggestions at:
  https://github.com/MendelMonteiro/StringFormatter/pull/10
  We now target netstandard2.0 as a minimum and provide specific
  net461/netcoreapp2.1 versions with #ifdef
- Added support for CopyTo(Span<char>...)/CopyTo(Span<byte> with the
  netcoreapp2.1 taking advantage of built-in support for Span<T> in
  System.Encoding
- Added Append(Span<char>) support
- Rename CheckCapacity -> EnsureCapacity for better readability
- Added basic span unit tests