### PR TITLE
Handle standard TimeSpan format strings

### DIFF
--- a/StringFormatter/Date.cs
+++ b/StringFormatter/Date.cs
@@ -1,20 +1,21 @@
+using System.Runtime.CompilerServices;
 using InlineIL;
 
 namespace System.Text.Formatting
 {
     internal class Date
     {
-        const char _standardFormatShort = 'd';
-        static readonly string _standardFormat = "yyyy-MM-dd";
+        private const char _standardFormatShort = 'd';
+        private const string _standardFormat = "yyyy-MM-dd";
 
         public static unsafe void Format(StringBuffer formatter, DateTime dateTime, StringView format)
         {
             IL.DeclareLocals(false);
 
-            var tempCharsLength = 4;
-            char* tempChars = stackalloc char[tempCharsLength];
+            const int tempCharsLength = 4;
+            var tempChars = stackalloc char[tempCharsLength];
 
-            if (IsStandardShortFormat(format))
+            if (IsStandardShortDateFormat(format))
             {
                 var (year, month, day) = dateTime;
                 AppendNumber(formatter, year, 4, tempChars, tempCharsLength);
@@ -42,24 +43,13 @@ namespace System.Text.Formatting
             }
         }
 
-        private static unsafe bool IsStandardShortFormat(StringView format)
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static unsafe bool IsStandardShortDateFormat(StringView format)
         {
             if (format.Length == 1 && format.Data[0] == _standardFormatShort)
                 return true;
 
-            if (_standardFormat.Length != format.Length)
-                return false;
-
-            fixed (char* standardFormat = _standardFormat)
-            {
-                for (var i = 0; i < format.Length; i++)
-                {
-                    if (*(format.Data + i) != *(standardFormat + i))
-                        return false;
-                }
-            }
-
-            return true;
+            return format == _standardFormat;
         }
 
         public static unsafe void Format(StringBuffer formatter, TimeSpan timeSpan, StringView format)
@@ -69,6 +59,8 @@ namespace System.Text.Formatting
             const int tempCharsLength = 7;
             var tempChars = stackalloc char[tempCharsLength];
 
+            var fmt = ParseTimeSpanFormat(format);
+
             if (timeSpan.Ticks < 0)
             {
                 formatter.Append('-');
@@ -77,18 +69,30 @@ namespace System.Text.Formatting
 
             var (days, hours, minutes, seconds, ticks) = timeSpan;
 
-            if (days > 0) {
+            if (days > 0 || fmt == TimeSpanFormat.GeneralLong)
+            {
                 formatter.Append(days, StringView.Empty);
-                formatter.Append('.');
+                formatter.Append(fmt == TimeSpanFormat.Constant ? '.' : ':');
             }
 
-            AppendNumber(formatter, hours, 2, tempChars, tempCharsLength);
+            if (fmt == TimeSpanFormat.GeneralShort)
+                formatter.Append(hours, StringView.Empty);
+            else
+                AppendNumber(formatter, hours, 2, tempChars, tempCharsLength);
+
             formatter.Append(':');
             AppendNumber(formatter, minutes, 2, tempChars, tempCharsLength);
             formatter.Append(':');
             AppendNumber(formatter, seconds, 2, tempChars, tempCharsLength);
-            formatter.Append('.');
-            AppendNumber(formatter, ticks, 7, tempChars, tempCharsLength);
+
+            if (ticks != 0 || fmt == TimeSpanFormat.GeneralLong)
+            {
+                formatter.Append('.');
+                AppendNumber(formatter, ticks, 7, tempChars, tempCharsLength);
+
+                if (fmt == TimeSpanFormat.GeneralShort)
+                    formatter.TrimEnd('0');
+            }
         }
 
         private static unsafe void AppendNumber(StringBuffer formatter, int value, int maxLength, char* tempChars, int tempCharsLength)
@@ -99,6 +103,31 @@ namespace System.Text.Formatting
 
             Numeric.Int32ToDecChars(tempChars + tempCharsLength, (uint)value, 0);
             formatter.Append(tempChars + startOffset, maxLength);
+        }
+
+        private static unsafe TimeSpanFormat ParseTimeSpanFormat(StringView format)
+        {
+            if (format.Length != 1)
+                return TimeSpanFormat.Constant;
+
+            switch (format.Data[0])
+            {
+                case 'g':
+                    return TimeSpanFormat.GeneralShort;
+
+                case 'G':
+                    return TimeSpanFormat.GeneralLong;
+
+                default:
+                    return TimeSpanFormat.Constant;
+            }
+        }
+
+        private enum TimeSpanFormat
+        {
+            Constant,
+            GeneralShort,
+            GeneralLong
         }
     }
 }

--- a/StringFormatter/StringBuffer.cs
+++ b/StringFormatter/StringBuffer.cs
@@ -817,6 +817,12 @@ namespace System.Text.Formatting
             return *curr;
         }
 
+        public void TrimEnd(char c)
+        {
+            while (currentCount != 0 && buffer[currentCount - 1] == c)
+                --currentCount;
+        }
+
         static void ThrowError()
         {
             throw new FormatException(SR.InvalidFormatString);


### PR DESCRIPTION
- Handles the standard TimeSpan format strings: `c`, `g` and `G` (but always in the invariant culture)
- Makes `c` the default format

We may want to support an intermediate format such as `[-][d'.']hh':'mm':'ss['.'fff]` but I'm not sure how to handle that, short of supporting custom format strings.